### PR TITLE
Fix conflict with System.Diagnostics.DiagnosticSource.dll

### DIFF
--- a/src/Jowsy.Revit.KernelAddin/App.cs
+++ b/src/Jowsy.Revit.KernelAddin/App.cs
@@ -42,8 +42,11 @@ namespace Jowsy.Revit.KernelAddin
 
             application.RegisterDockablePane(DockablePaneId, "NETInteractive Revit Kernel", kernelPaneProvider);
 
+            //Force loading of assembly
+            var activityType = typeof(System.Diagnostics.Activity); 
+
             //TODO: Implement a better formatter! Maybe based on RevitLookup?
-           Formatter.SetPreferredMimeTypesFor(typeof(Element), "text/html");
+            Formatter.SetPreferredMimeTypesFor(typeof(Element), "text/html");
 
             //It's common for object graphs to contain reference cycles.
             //The .NET Interactive formatter will traverse object graphs but in order to avoid both oversized outputs and possible

--- a/src/Jowsy.Revit.KernelAddin/Jowsy.Revit.KernelAddin.csproj
+++ b/src/Jowsy.Revit.KernelAddin/Jowsy.Revit.KernelAddin.csproj
@@ -57,6 +57,7 @@
         <ItemGroup>
             <AddinFiles Include="$(RootDir)**\Jowsy.Revit.KernelAddin.dll"/>
             <AddinFiles Include="$(RootDir)**\System.Text.Json.dll"/>
+			<AddinFiles Include="$(RootDir)**\System.Diagnostics.DiagnosticSource.dll"/>
         </ItemGroup>
         <Message Text="Copy files to Addin folder" Importance="high"/>
         <Copy SourceFiles="@(AddinFiles)" DestinationFolder="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\%(RecursiveDir)" Condition="$(Configuration.Contains('Debug'))"/>

--- a/src/Jowsy.Revit.KernelAddin/Jowsy.Revit.KernelAddin.csproj
+++ b/src/Jowsy.Revit.KernelAddin/Jowsy.Revit.KernelAddin.csproj
@@ -57,7 +57,7 @@
         <ItemGroup>
             <AddinFiles Include="$(RootDir)**\Jowsy.Revit.KernelAddin.dll"/>
             <AddinFiles Include="$(RootDir)**\System.Text.Json.dll"/>
-			<AddinFiles Include="$(RootDir)**\System.Diagnostics.DiagnosticSource.dll"/>
+            <AddinFiles Include="$(RootDir)**\System.Diagnostics.DiagnosticSource.dll"/>
         </ItemGroup>
         <Message Text="Copy files to Addin folder" Importance="high"/>
         <Copy SourceFiles="@(AddinFiles)" DestinationFolder="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\%(RecursiveDir)" Condition="$(Configuration.Contains('Debug'))"/>


### PR DESCRIPTION
The application crashes due to conflicting assemblies with Dynamo For Revit.
Added dll as embedded resource.

Tested with following addins:
![image](https://github.com/jowsy/bim-net-interactive/assets/78738216/a735844e-ed65-4090-a78f-c45e8f98da5e)

**How to test:**
1. Open Revit
2. Click 'Start' in Kernel viewer
Revit should not crash and the status should change.